### PR TITLE
[WIP] Improving dependency management and solving several bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ Data
 resources
 Results
 .vscode
+
+# SimPET paths
+simpet_paths.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy==1.24.1
+scipy==1.10.0
+nibabel==3.2.2
+matplotlib==3.6.3
+pandas==1.5.2
+pyaml==21.10.1
+nipype==1.8.4
+nilearn==0.10.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ This script installs the necessary files to run simpet, including all the requir
 Don't run this script if you think all the needed dependencies are already fulfilled.
 """
 import os
-from os.path import join, basename, exists
+from os.path import join, basename, exists, abspath
 import shutil
 from multiprocessing import cpu_count
 
@@ -139,7 +139,7 @@ def install_stir(stir_dir, simset_dir, log_file):
     rsystem(icom)
 
     os.chdir(build_dir)
-    rsystem('cmake ../STIR/')
+    rsystem(f"cmake {abspath('../STIR/')}")
 
     makefile = join(build_dir, 'CMakeCache.txt')
     newmakefile = join(stir_dir, 'build', 'new_CMakeCache.txt')
@@ -166,7 +166,7 @@ def install_stir(stir_dir, simset_dir, log_file):
     f_new.close()
 
     shutil.move(newmakefile, makefile)
-    rsystem('cmake ../STIR/')
+    rsystem(f"cmake {abspath('../STIR/')}")
 
     print('Building STIR....')
     icom = 'make -s -j%s & make install' % str(cpu_count())

--- a/setup.py
+++ b/setup.py
@@ -36,27 +36,27 @@ def install_soap():
     """
     # Install SOAP
 
-    icom = 'sudo apt install unzip -y -q'
+    icom = 'sudo apt-get install unzip -y -q'
     rsystem(icom)
 
-    icom = 'sudo apt install sshpass -y -q'
+    icom = 'sudo apt-get install sshpass -y -q'
     rsystem(icom)
 
-    icom = 'sudo apt install libboost-dev libboost-all-dev -y -q'
+    icom = 'sudo apt-get install libboost-dev libboost-all-dev -y -q'
     rsystem(icom)
 
-    icom = 'sudo apt install libpcre3 libpcre3-dev -y -q'
+    icom = 'sudo apt-get install libpcre3 libpcre3-dev -y -q'
     rsystem(icom)
 
-    icom = 'sudo apt install libncurses-dev -y -q'
+    icom = 'sudo apt-get install libncurses-dev -y -q'
     rsystem(icom)
 
     # Install cmake (needed for STIR)
-    icom = 'sudo apt install cmake -y -q'
+    icom = 'sudo apt-get install cmake -y -q'
     rsystem(icom)
 
     # Install swig (needed for STIR)
-    icom = 'sudo apt install swig -y -q'
+    icom = 'sudo apt-get install swig -y -q'
     rsystem(icom)
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,19 +36,10 @@ def install_soap():
     """
     # Install SOAP
 
-    icom = 'sudo apt install python3 -y -q'
-    rsystem(icom)
-
     icom = 'sudo apt install unzip -y -q'
     rsystem(icom)
 
     icom = 'sudo apt install sshpass -y -q'
-    rsystem(icom)
-
-    icom = 'sudo apt install python3-pip -y -q'
-    rsystem(icom)
-
-    icom = 'sudo apt install ipython3 -y -q'
     rsystem(icom)
 
     icom = 'sudo apt install libboost-dev libboost-all-dev -y -q'

--- a/setup.py
+++ b/setup.py
@@ -51,44 +51,12 @@ def install_soap():
     icom = 'sudo apt install libncurses-dev -y -q'
     rsystem(icom)
 
-    # Install and upgrade PIP
-    icom = 'sudo pip3 install -U PyYAML'
-    rsystem(icom)
-
-    # Install numpy
-    icom = 'sudo apt install python3-numpy -y -q'
-    rsystem(icom)
-
-    # Install Scipy
-    icom = 'sudo apt install python3-scipy -y -q'
-    rsystem(icom)
-
-    # Install Nibabel
-    icom = 'sudo apt install python3-nibabel -y -q'
-    rsystem(icom)
-
-    # Install matplotlib
-    icom = 'sudo apt install python3-matplotlib -y -q'
-    rsystem(icom)
-
-    # Install Pandas
-    icom = 'sudo apt install python3-pandas -y -q'
-    rsystem(icom)
-
-    # Install nilearn
-    icom = 'sudo pip3 install -U nilearn'
-    rsystem(icom)
-
     # Install cmake (needed for STIR)
     icom = 'sudo apt install cmake -y -q'
     rsystem(icom)
 
     # Install swig (needed for STIR)
     icom = 'sudo apt install swig -y -q'
-    rsystem(icom)
-
-    # Install NIPYPE
-    icom = 'sudo pip3 install nipype'
     rsystem(icom)
 
 

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -700,11 +700,9 @@ def resampleZvoxelSize(image_hdr, zOutputvoxelSize, log_file):
     img = nib.load(image_hdr)
     x_VoxelSize = img.header['pixdim'][1]
     y_VoxelSize = img.header['pixdim'][2]
-    target_affine =  np.diag((x_VoxelSize,y_VoxelSize,zOutputvoxelSize))
-    res_img=image.resample_img(image_hdr[0:-3]+'img',target_affine)
+    taget_vsize =  (x_VoxelSize,y_VoxelSize,zOutputvoxelSize)
+    res_img = nib.processing.resample_to_output(img, taget_vsize, out_class=img.__class__)
     nib.save(res_img,image_hdr)
-    # res_img=image.resample_img(image_hdr,target_affine)
-    # nib.save(res_img,image_hdr[0:-4]+"_resZ.hdr")
     
     return image_hdr
 

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -689,11 +689,9 @@ def convert_simset_sino_to_stir(input_img, output=False):
 def resampleXYvoxelSizes(image_hdr, xyVoxelSize, log_file):
     img = nib.load(image_hdr)
     z_VoxelSize =img.header['pixdim'][3]
-    target_affine = np.diag((xyVoxelSize,xyVoxelSize,z_VoxelSize))
-    res_img=image.resample_img(image_hdr[0:-3]+'img',target_affine)
+    taget_vsize = (xyVoxelSize,xyVoxelSize,z_VoxelSize)
+    res_img = nib.processing.resample_to_output(img, taget_vsize, out_class=img.__class__)
     nib.save(res_img,image_hdr)
-    # res_img=image.resample_img(image_hdr,target_affine)
-    # nib.save(res_img,image_hdr[0:-4]+"_resXY.hdr")
     
     return image_hdr
 


### PR DESCRIPTION
In this PR:
- Adding a `requirements.txt` in order to keep the version of the python packages fixed and avoid incompatibilities (remove installation from `setup.py`).
- Using [` nibabel.processing.resample_to_output` ](https://nipy.org/nibabel/reference/nibabel.processing.html#resample-to-output) instead of [`nilearn.image.resample_img`](https://nilearn.github.io/dev/modules/generated/nilearn.image.resample_img.html) since the latter is not compatible with [`nibabel.spm2analyze.Spm2AnalyzeImage`](https://nipy.org/nibabel/reference/nibabel.spm2analyze.html#nibabel.spm2analyze.Spm2AnalyzeImage) interface. 
- Resolving some relpaths in `setup.py` to make it compatible with Docker (Docker struggle with relpaths), the repository might be containerized in future versions.
- Adding `simpet_paths.sh` to `.gitignore`.